### PR TITLE
Update bazel to match only extension or whole name

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: bazel buildifier
     description: Runs `buildifier`, requires buildifier binary
     entry: buildifier
-    files: '(^(|.*/)(BUILD\.bazel|BUILD)|\.BUILD)$' 
+    files: '^(.*/)?(BUILD\.bazel|BUILD)$|\.BUILD$' 
     language: system
 
 -   id: do-not-submit

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: bazel buildifier
     description: Runs `buildifier`, requires buildifier binary
     entry: buildifier
-    files: 'BUILD.bazel|BUILD|WORKSPACE'
+    files: '(^(BUILD\.bazel|BUILD)|/\2|\.BUILD)$' 
     language: system
 
 -   id: do-not-submit
@@ -11,3 +11,4 @@
     entry: check_do_not_submit.py
     language: script
     files: '.*'
+

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: bazel buildifier
     description: Runs `buildifier`, requires buildifier binary
     entry: buildifier
-    files: '(^(BUILD\.bazel|BUILD)|/\2|\.BUILD)$' 
+    files: '(^(|.*/)(BUILD\.bazel|BUILD)|\.BUILD)$' 
     language: system
 
 -   id: do-not-submit


### PR DESCRIPTION
The hook was originally matching all files in the repository as long as they had `BUILD` or `BUILD.bazel` in them. This commit ensures that, for example, `BUILD.bazel` and `whatever/BUILD.bazel` match, but not `whateverBUILD.bazelasdf`. It also adds support for `whatever.BUILD` files.