### PR TITLE
Add *.bzl to buildifier files pattern

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: bazel buildifier
     description: Runs `buildifier`, requires buildifier binary
     entry: buildifier
-    files: '^(.*/)?(BUILD\.bazel|BUILD)$|\.BUILD$' 
+    files: '^(.*/)?(BUILD\.bazel|BUILD)$|\.BUILD$|\.bzl$'
     language: system
 
 -   id: do-not-submit


### PR DESCRIPTION
According to doc: Bazel extensions are files ending in .bzl