### PR TITLE
Add `WORKSPACE` to file pattern for `buildifier`.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: bazel buildifier
     description: Runs `buildifier`, requires buildifier binary
     entry: buildifier
-    files: '^(.*/)?(BUILD\.bazel|BUILD)$|\.BUILD$|\.bzl$'
+    files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
     language: system
 
 -   id: do-not-submit


### PR DESCRIPTION
These files are also formatted by the tool.