### PR TITLE
chore(pre-commit): add `black` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+        exclude: git-clang-format

--- a/clang_format.py
+++ b/clang_format.py
@@ -87,8 +87,8 @@ def check_hash(sha: str, file: Path):
 def clang_format_path() -> Path:
     """Gets the path of the relevant clang-format binary.
 
-  Downloads it if necessary.
-  """
+    Downloads it if necessary.
+    """
     try:
         base_cachedir = Path(os.environ["XDG_CACHE_HOME"])
     except KeyError:


### PR DESCRIPTION
Adds the black formatter hook to the project.

Makes sure that any commits format the Python files.

Ignores the upstream `git-clang-format`.

```
pre-commit install-hooks
pre-commit run --all-files
```

Hoping to get a series of hooks in before contributing functional code changes. Will hopefully align the project on code quality/style.