### PR TITLE
Jtravert/dep issue python3.6

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -20,12 +20,14 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
+# Depending on the verion of python running, typing may or may not contain
+# Final.  If importing it from typing doesn't work, we'll import it from
+# typing_extensions (its location for older python versions).
 try:
     from typing import Final, Mapping, Optional, Sequence, Tuple
 except ImportError:
     from typing_extensions import Final
     from typing import Mapping, Optional, Sequence, Tuple
-    
 
 # clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/

--- a/clang_format.py
+++ b/clang_format.py
@@ -20,7 +20,12 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
-from typing import Final, Mapping, Optional, Sequence, Tuple
+try:
+    from typing import Final, Mapping, Optional, Sequence, Tuple
+except ImportError:
+    from typing_extensions import Final
+    from typing import Mapping, Optional, Sequence, Tuple
+    
 
 # clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/

--- a/git-clang-format
+++ b/git-clang-format
@@ -77,7 +77,7 @@ def main():
       'c', 'h',  # C
       'm',  # ObjC
       'mm',  # ObjC++
-      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx',  # C++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'tpp',  # C++
       'cu',  # CUDA
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers


### PR DESCRIPTION
Hit an import error when using an updated version of this script on my setup (running python 3.6):
```Traceback (most recent call last):
  File "~/.cache/pre-commit/repo6tcjuqfw/clang_format.py", line 23, in <module>
    from typing import Final, Mapping, Optional, Sequence, Tuple
ImportError: cannot import name 'Final'```

Found out that `Final` was added to typing v3.8, only available for python 3.7+, but was actually backported in `typing_extensions` for  python 3.5 and 3.6 (see [the module's page](https://pypi.org/project/typing-extensions/) for more details).
So, here is a quick fix for that.