### PR TITLE
Backwards-compatibility for python 3.5+

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -30,7 +30,7 @@ except ImportError:
     from typing_extensions import Final
     from typing import Mapping, Optional, Sequence, Tuple
 
-    # clang-format sha1s were retrieved at
+# clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/
 # The below shas are tested across different os to identify the version.
 # For getting the list a script is written to download all the sha's

--- a/clang_format.py
+++ b/clang_format.py
@@ -20,9 +20,17 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
-from typing import Final, Mapping, Optional, Sequence, Tuple
+# typing module available for python 3.6 or lower does not include Final.
+# This leads to ImportError. In case this happens, we can try to import
+# Final from typing_extensions, which is a backport of the newest typing
+# functionalities into older python versions (3.5 and 3.6).
+try:
+    from typing import Final, Mapping, Optional, Sequence, Tuple
+except ImportError:
+    from typing_extensions import Final
+    from typing import Mapping, Optional, Sequence, Tuple
 
-# clang-format sha1s were retrieved at
+    # clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/
 # The below shas are tested across different os to identify the version.
 # For getting the list a script is written to download all the sha's


### PR DESCRIPTION
Hit an import error when using an updated version of this script on my setup (running python 3.6):
```
Traceback (most recent call last):
  File "~/.cache/pre-commit/repo6tcjuqfw/clang_format.py", line 23, in <module>
    from typing import Final, Mapping, Optional, Sequence, Tuple
ImportError: cannot import name 'Final'
```

Found out that `Final` was added to typing v3.8, only available for python 3.7+, but was actually backported in `typing_extensions` for  python 3.5 and 3.6 (see [the module's page](https://pypi.org/project/typing-extensions/) for more details).
So, here is a quick fix for that.