### PR TITLE
Add clang format v16

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
     name: clang-format-diff
     entry: clang_format.py
     language: script
-    args: ['15.0.0','diff']
+    args: ['16.0.0','diff']
     require_serial: true
 
 
@@ -37,7 +37,7 @@
     name: clang-format-whole-file
     entry: clang_format.py
     language: script
-    args: ['15.0.0','whole-file']
+    args: ['16.0.0','whole-file']
     require_serial: false
 
 -   id: clang-format-diff-3.6.0
@@ -150,4 +150,18 @@
     entry: clang_format.py
     language: script
     args: ['15.0.0','whole-file']
+    require_serial: false
+
+-   id: clang-format-diff-16.0.0
+    name: clang-format-diff-16.0.0
+    entry: clang_format.py
+    language: script
+    args: ['16.0.0','diff']
+    require_serial: true
+
+-   id: clang-format-whole-file-16.0.0
+    name: clang-format-whole-file-16.0.0
+    entry: clang_format.py
+    language: script
+    args: ['16.0.0','whole-file']
     require_serial: false

--- a/clang_format.py
+++ b/clang_format.py
@@ -84,6 +84,11 @@ CLANG_FORMAT_SHAS: Final[Mapping[Tuple[int, int, int], Mapping[str, str],]] = {
         "Darwin": "a1b33be85faf2578f3101d7806e443e1c0949498",
         "Windows": "66882fadbf9e99cc00b8677d8c1e7e8b3cfdf4fe",
     },
+    (16, 0, 0): {
+        "Linux": "6ef2183a178a53e47e4448dbe192b1d8d5290222",
+        "Darwin": "1c125f1d882babd1a930fcd5b4fd80bba3f5321e",
+        "Windows": "d88796ff22d70c7d5ede62636daa220ccd238f06",
+    },
 }
 
 


### PR DESCRIPTION
I looked up the sha's by going over git log [here](https://chromium.googlesource.com/chromium/src/+log/refs/heads/main/buildtools/linux64/clang-format.sha1).