### PR TITLE
bump clang format version to 18.0.0

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
     name: clang-format-diff
     entry: clang_format.py
     language: script
-    args: ['16.0.0','diff']
+    args: ['18.0.0','diff']
     require_serial: true
 
 
@@ -37,7 +37,7 @@
     name: clang-format-whole-file
     entry: clang_format.py
     language: script
-    args: ['16.0.0','whole-file']
+    args: ['18.0.0','whole-file']
     require_serial: false
 
 -   id: clang-format-diff-3.6.0
@@ -164,4 +164,18 @@
     entry: clang_format.py
     language: script
     args: ['16.0.0','whole-file']
+    require_serial: false
+
+-   id: clang-format-diff-18.0.0
+    name: clang-format-diff-18.0.0
+    entry: clang_format.py
+    language: script
+    args: ['18.0.0','diff']
+    require_serial: true
+
+-   id: clang-format-whole-file-18.0.0
+    name: clang-format-whole-file-18.0.0
+    entry: clang_format.py
+    language: script
+    args: ['18.0.0','whole-file']
     require_serial: false

--- a/clang_format.py
+++ b/clang_format.py
@@ -89,6 +89,11 @@ CLANG_FORMAT_SHAS: Final[Mapping[Tuple[int, int, int], Mapping[str, str],]] = {
         "Darwin": "1c125f1d882babd1a930fcd5b4fd80bba3f5321e",
         "Windows": "d88796ff22d70c7d5ede62636daa220ccd238f06",
     },
+    (18, 0, 0): {
+        "Linux": "b42097ca924d1f1736a5a7806068fed9d7345eb4",
+        "Darwin": "96c34e77259c4cc1fc7bdf067fc058bfd341ab85",
+        "Windows": "49458d4c1e884a38308f8dc6a2c7eb55fc478755",
+    }
 }
 
 


### PR DESCRIPTION
shas from: [here](https://chromium.googlesource.com/chromium/src/+/17e361b25633686d56dce7c2b59d99ac13fcc74c/buildtools)